### PR TITLE
support AWS_ACCOUNT_ID var replacement, add REGION to iam files

### DIFF
--- a/iam/Cognito_LambdAuthAuth_Role.json
+++ b/iam/Cognito_LambdAuthAuth_Role.json
@@ -17,13 +17,13 @@
                 "lambda:InvokeFunction"
             ],
             "Resource": [
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthCreateUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthVerifyUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthChangePassword",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLostUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLostPassword",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthResetPassword",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLogin"
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthCreateUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthVerifyUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthChangePassword",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLostUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLostPassword",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthResetPassword",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLogin"
             ]
         }
     ]

--- a/iam/Cognito_LambdAuthUnauth_Role.json
+++ b/iam/Cognito_LambdAuthUnauth_Role.json
@@ -17,12 +17,12 @@
                 "lambda:InvokeFunction"
             ],
             "Resource": [
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthCreateUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthVerifyUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLostUser",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLostPassword",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthResetPassword",
-                "arn:aws:lambda:eu-west-1:<AWS_ACCOUNT_ID>:function:LambdAuthLogin"
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthCreateUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthVerifyUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLostUser",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLostPassword",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthResetPassword",
+                "arn:aws:lambda:<REGION>:<AWS_ACCOUNT_ID>:function:LambdAuthLogin"
             ]
         }
     ]

--- a/iam/LambdAuthChangePassword.json
+++ b/iam/LambdAuthChangePassword.json
@@ -7,7 +7,7 @@
                 "dynamodb:UpdateItem"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+            "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
         },
         {
             "Sid": "",

--- a/iam/LambdAuthCreateUser.json
+++ b/iam/LambdAuthCreateUser.json
@@ -6,7 +6,7 @@
                 "dynamodb:PutItem"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+            "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
         },
         {
             "Effect": "Allow",

--- a/iam/LambdAuthLogin.json
+++ b/iam/LambdAuthLogin.json
@@ -6,14 +6,14 @@
                 "dynamodb:GetItem"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+            "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
         },
         {
             "Effect": "Allow",
             "Action": [
                 "cognito-identity:GetOpenIdTokenForDeveloperIdentity"
             ],
-            "Resource": "arn:aws:cognito-identity:eu-west-1:<AWS_ACCOUNT_ID>:identitypool/<IDENTITY_POOL_ID>"
+            "Resource": "arn:aws:cognito-identity:<REGION>:<AWS_ACCOUNT_ID>:identitypool/<IDENTITY_POOL_ID>"
         },
         {
             "Sid": "",

--- a/iam/LambdAuthLostPassword.json
+++ b/iam/LambdAuthLostPassword.json
@@ -7,7 +7,7 @@
 	              "dynamodb:UpdateItem"
 	           ],
 	          "Effect": "Allow",
-	          "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+	          "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
 	      },
         {
             "Effect": "Allow",

--- a/iam/LambdAuthResetPassword.json
+++ b/iam/LambdAuthResetPassword.json
@@ -7,7 +7,7 @@
                 "dynamodb:UpdateItem"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+            "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
         },
         {
             "Sid": "",

--- a/iam/LambdAuthVerifyUser.json
+++ b/iam/LambdAuthVerifyUser.json
@@ -7,7 +7,7 @@
                 "dynamodb:UpdateItem"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:eu-west-1:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
+            "Resource": "arn:aws:dynamodb:<REGION>:<AWS_ACCOUNT_ID>:table/<DYNAMODB_TABLE>"
         },
         {
             "Sid": "",

--- a/init.sh
+++ b/init.sh
@@ -93,7 +93,7 @@ for f in $(ls -1 Cognito*); do
   echo "Creating role $role end"
 done
 echo "Setting identity pool roles begin..."
-roles='{"unauthenticated":"arn:aws:iam::$AWS_ACCOUNT_ID:role/'"$unauthRole"'","authenticated":"arn:aws:iam::$AWS_ACCOUNT_ID:role/'"$authRole"'"}'
+roles="{\"unauthenticated\":\"arn:aws:iam::$AWS_ACCOUNT_ID:role/$unauthRole\",\"authenticated\":\"arn:aws:iam::$AWS_ACCOUNT_ID:role/$authRole\"}"
 echo "Roles: $roles"
 aws cognito-identity set-identity-pool-roles \
   --identity-pool-id $IDENTITY_POOL_ID \

--- a/init.sh
+++ b/init.sh
@@ -69,6 +69,7 @@ for f in $(ls -1 trust*); do
       -e "s/<DYNAMODB_TABLE>/$DDB_TABLE/g" \
       -e "s/<DYNAMODB_EMAIL_INDEX>/$DDB_EMAIL_INDEX/g" \
       -e "s/<IDENTITY_POOL_ID>/$IDENTITY_POOL_ID/g" \
+      -e "s/<REGION>/$REGION/g" \
       $f > edit/$f
   echo "Editing trust from $f end"
 done
@@ -79,6 +80,7 @@ for f in $(ls -1 Cognito*); do
       -e "s/<DYNAMODB_TABLE>/$DDB_TABLE/g" \
       -e "s/<DYNAMODB_EMAIL_INDEX>/$DDB_EMAIL_INDEX/g" \
       -e "s/<IDENTITY_POOL_ID>/$IDENTITY_POOL_ID/g" \
+      -e "s/<REGION>/$REGION/g" \
 	      $f > edit/$f
   if [[ $f == *Unauth_* ]]; then
     trust="trust_policy_cognito_unauth.json"
@@ -109,6 +111,7 @@ for f in $(ls -1 LambdAuth*); do
       -e "s/<DYNAMODB_TABLE>/$DDB_TABLE/g" \
       -e "s/<DYNAMODB_EMAIL_INDEX>/$DDB_EMAIL_INDEX/g" \
       -e "s/<IDENTITY_POOL_ID>/$IDENTITY_POOL_ID/g" \
+      -e "s/<REGION>/$REGION/g" \
       $f > edit/$f
 	trust="trust_policy_lambda.json"
   aws iam create-role --role-name $role --assume-role-policy-document file://edit/$trust


### PR DESCRIPTION
Allow AWS_ACCOUNT_ID to be replaced in init.sh roles var.
Add REGION var support in iam files.
