### PR TITLE
lambda create-function: wrapped the account_id variable in quotes

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -132,7 +132,7 @@ for f in $(ls -1|grep ^LambdAuth); do
   zip -r $f.zip index.js config.json
   aws lambda create-function --function-name ${f} \
       --runtime nodejs \
-      --role arn:aws:iam::$AWS_ACCOUNT_ID:role/${f} \
+      --role arn:aws:iam::"$AWS_ACCOUNT_ID":role/${f} \
       --handler index.handler \
       --zip-file fileb://${f}.zip \
 	  	--region $REGION


### PR DESCRIPTION
`init.sh` fails to create the lambda functions as the role has two characters clipped due to the missing quotes.
