### PR TITLE
switched to nodejs4.3

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -138,7 +138,7 @@ for f in $(ls -1|grep ^LambdAuth); do
   cd $f
   zip -r $f.zip index.js config.json
   aws lambda create-function --function-name ${f} \
-      --runtime nodejs \
+      --runtime nodejs4.3 \
       --role arn:aws:iam::"$AWS_ACCOUNT_ID":role/${f} \
       --handler index.handler \
       --zip-file fileb://${f}.zip \


### PR DESCRIPTION
AWS is suggesting using nodejs 4.3. When switching the lambda function after creating with nodejs 0.10 the wrong libraries are getting used. You need to re-deploy the function.
That's why I changed the creation to nodejs 4.3
