### PR TITLE
Add CLI_PROFILE key in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `init.sh` script requires a configured [AWS Command Line Interface (CLI)](ht
 **Before running the `init.sh` script, set up your configuration in the `config.json` file**:
 
 - your AWS account (12-digit number)
+- name of your CLI profile. This is the CLI profile that you want to represent while running `./init.sh` from the command-line. This value is usually found in square brackets inside the `~/.aws/credentials` file (`%UserProfile%\.aws\credentials` file in Windows) after installing the AWS CLI tools for your operating system. For more information, you may refer to the section called [Named Profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles) in the AWS CLI tools [user guide](http://docs.aws.amazon.com/cli/latest/userguide/).
 - the AWS region (e.g. "eu-west-1")
 - the Amazon S3 bucket to use for the sample HTML pages
 - the Cache-Control: max-age value, in seconds, to use on Amazon S3 (e.g. if distributed by [Amazon CloudFront](http://aws.amazon.com/cloudfront/) or another CDN)
@@ -55,6 +56,7 @@ The `init.sh` script requires a configured [AWS Command Line Interface (CLI)](ht
 ```json
 {
   "AWS_ACCOUNT_ID": "123412341234",
+  "CLI_PROFILE": "default",
   "REGION": "eu-west-1",
   "BUCKET": "bucket",
   "MAX_AGE": "10",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `init.sh` script requires a configured [AWS Command Line Interface (CLI)](ht
 
 **Before running the `init.sh` script, set up your configuration in the `config.json` file**:
 
-- your AWS account (12-digit number)
+- your AWS account (12-digit number). If an alias happens to be set for your root account, then you will need to go to ***Support > Support Center*** of your AWS Console and find your ***Account Number*** from the top right corner.
 - name of your CLI profile. This is the CLI profile that you want to represent while running `./init.sh` from the command-line. This value is usually found in square brackets inside the `~/.aws/credentials` file (`%UserProfile%\.aws\credentials` file in Windows) after installing the AWS CLI tools for your operating system. For more information, you may refer to the section called [Named Profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles) in the AWS CLI tools [user guide](http://docs.aws.amazon.com/cli/latest/userguide/).
 - the AWS region (e.g. "eu-west-1")
 - the Amazon S3 bucket to use for the sample HTML pages

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "AWS_ACCOUNT_ID": "123412341234",
+  "CLI_PROFILE": "default",
   "REGION": "eu-west-1",
   "BUCKET": "bucket",
   "MAX_AGE": "10",


### PR DESCRIPTION
Include 'CLI_PROFILE' key in config.json  …
- Update README.md file accordingly to explain where to get the value for 'CLI_PROFILE' from

---

Update README.md file on how to get 12 digit account number if an alias has been set for the account
