### PR TITLE
Bugfix: query IdentityPoolName from all available identitiy pools instead of just the last 1 pool

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -43,7 +43,7 @@ aws dynamodb create-table --table-name $DDB_TABLE \
 echo "Creating DynamoDB Table $DDB_TABLE end (creation still in progress)"
 
 # Create Cognito Identity Pool
-IDENTITY_POOL_ID=$(aws cognito-identity list-identity-pools --max-results 1 \
+IDENTITY_POOL_ID=$(aws cognito-identity list-identity-pools --max-results 60 \
 	  --query 'IdentityPools[?IdentityPoolName == `'$IDENTITY_POOL_NAME'`].IdentityPoolId' \
 	  --output text --region $REGION)
 if [ -z "$IDENTITY_POOL_ID" ]; then


### PR DESCRIPTION
without this setting, the `init.sh` script was ending up always creating a new identitypool without reusing the identity pool that already exists by the same name.

`--max-results` is a mandatory option in this CLI command.

maximum allowed number for `--max-results` is 60.
